### PR TITLE
Add WS interceptor of DNS requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,9 +250,9 @@ checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -314,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +343,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -444,12 +459,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -463,6 +497,16 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -589,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -599,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
@@ -649,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
@@ -675,6 +719,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -831,7 +885,9 @@ dependencies = [
 name = "hickory-dns"
 version = "0.24.0"
 dependencies = [
+ "async-trait",
  "clap",
+ "futures-channel",
  "futures-util",
  "hickory-client",
  "hickory-proto",
@@ -842,6 +898,7 @@ dependencies = [
  "rustls",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
  "webpki-roots",
@@ -1036,6 +1093,12 @@ dependencies = [
  "fnv",
  "itoa",
 ]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "idna"
@@ -1808,6 +1871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2131,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2219,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2293,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -101,6 +101,7 @@ name = "hickory-dns"
 path = "src/hickory-dns.rs"
 
 [dependencies]
+async-trait = "0.1.74"
 # clap features:
 # - suggestion for advanced help with error in cli
 # - derive for clap derive api
@@ -124,6 +125,7 @@ tracing-subscriber = { workspace = true, features = [
     "env-filter",
 ] }
 tokio = { workspace = true, features = ["time", "rt"] }
+tokio-tungstenite = "0.20.1"
 hickory-client.workspace = true
 hickory-proto.workspace = true
 hickory-server = { workspace = true, features = ["toml"] }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -113,6 +113,7 @@ clap = { workspace = true, default-features = false, features = [
     "derive",
     "suggestions",
 ] }
+futures-channel = "0.3.29"
 futures-util = { workspace = true, default-features = false, features = [
     "std",
 ] }

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -308,7 +308,7 @@ struct Cli {
 
     /// Listening port for WebSocket DNS request forwarder.
     /// Defaults to `8000`.
-    #[clap(long = "ws-port", default_value = 8000, value_name = "WS-PORT")]
+    #[clap(long = "ws-port", default_value = "8000", value_name = "WS-PORT")]
     pub(crate) ws_port: u16,
 
     /// Listening port for DNS over TLS queries,

--- a/bin/src/hickory-dns.rs
+++ b/bin/src/hickory-dns.rs
@@ -489,7 +489,7 @@ fn main() {
     // Ideally the processing would be n-threads for receiving, which hand off to m-threads for
     //  request handling. It would generally be the case that n <= m.
     info!("Server starting up");
-    let ws_future = ws.spawn("127.0.0.1:8000");
+    let ws_future = ws.spawn("0.0.0.0:8000");
 
     match runtime.block_on( futures_util::future::try_join(server.block_until_done(), ws_future)) {
         Ok(_) => {

--- a/bin/src/ws.rs
+++ b/bin/src/ws.rs
@@ -27,7 +27,7 @@ impl<D: RequestHandler> RequestInterceptor<D> {
 impl<D: RequestHandler> RequestHandler for RequestInterceptor<D> {
     async fn handle_request<R: ResponseHandler>(&self, request: &Request, response_handle: R) -> ResponseInfo {
         let qry = request.query();
-        let msg = format!("[{},{},{},{}]", request.src().ip(), qry.query_class(), qry.query_type(), qry.name());
+        let msg = format!("[\"{}\",\"{}\",\"{}\",\"{}\"]", request.src().ip(), qry.query_class(), qry.query_type(), qry.name());
 
         debug!("intercepted request from {msg}");
         self.ws.send_message(request.src().ip(), msg).await;

--- a/bin/src/ws.rs
+++ b/bin/src/ws.rs
@@ -1,21 +1,102 @@
+use std::collections::HashMap;
+use std::io::ErrorKind;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 use async_trait::async_trait;
+use futures_channel::mpsc::UnboundedSender;
+use futures_util::StreamExt;
+use futures_util::lock::Mutex;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, error, info};
+use hickory_proto::error::ProtoError;
 use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
 
 pub(crate) struct RequestInterceptor<D: RequestHandler> {
-    downstream: D
+    downstream: D,
+    ws: Arc<WsServer>
 }
 
 impl<D: RequestHandler> RequestInterceptor<D> {
-    pub(crate) fn new(downstream: D) -> Self {
-        Self { downstream }
+    pub(crate) fn new(downstream: D, ws: Arc<WsServer>) -> Self {
+        Self { downstream, ws }
     }
 }
 
 #[async_trait]
 impl<D: RequestHandler> RequestHandler for RequestInterceptor<D> {
     async fn handle_request<R: ResponseHandler>(&self, request: &Request, response_handle: R) -> ResponseInfo {
-        println!("intercepted request from {}: {} {} {}", request.src(), request.query().query_class(), request.query().query_type(), request.query().name());
+        let qry = request.query();
+        let msg = format!("[{},{},{},{}]", request.src().ip(), qry.query_class(), qry.query_type(), qry.name());
+
+        debug!("intercepted request from {msg}");
+        self.ws.send_message(request.src().ip(), msg).await;
+
         self.downstream.handle_request(request, response_handle).await
     }
 }
 
+type PeerMap = HashMap<String, UnboundedSender<String>>;
+
+pub(crate) struct WsServer {
+    connections: Arc<Mutex<PeerMap>>,
+}
+
+impl WsServer {
+    pub(crate) fn new() -> Self {
+        Self {
+            connections: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) async fn send_message(&self, to: IpAddr, message: String) {
+        let to_str = to.to_string();
+
+        let mut conns = self.connections.lock().await;
+        if let Some(sender) = conns.get(&to_str) {
+            match sender.unbounded_send(message) {
+                Ok(_) => {
+                    debug!("message sent to {to}")
+                }
+                Err(e) => {
+                    error!("failed to deliver message to {to}");
+                    if e.is_disconnected() {
+                        conns.remove(&to_str);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn spawn(&self, binding: &str) -> Result<(), ProtoError> {
+        let bound_socket = TcpListener::bind(binding).await?;
+        info!("WS listening on {binding}");
+
+        while let Ok((stream, addr)) = bound_socket.accept().await {
+            self.accept(addr, stream).await.map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+        }
+
+        debug!("WS listening done");
+        Ok(())
+    }
+
+    async fn accept(&self, addr: SocketAddr, stream: TcpStream) -> Result<(), tokio_tungstenite::tungstenite::Error>{
+        let ws_stream = tokio_tungstenite::accept_async(stream).await?;
+        let (write, read) = ws_stream.split();
+
+        let (tx, rx) = futures_channel::mpsc::unbounded();
+        self.connections.lock().await.insert(addr.ip().to_string(), tx);
+        debug!("WS peer {addr} connected");
+
+        let peer_map = self.connections.clone();
+        tokio::spawn(async move {
+            let _ = rx.map(|s| Ok(Message::Text(s))).forward(write).await;
+
+            debug!("WS peer {addr} disconnected");
+            peer_map.lock().await.remove(&addr.ip().to_string());
+            std::mem::drop(read);
+        });
+
+        Ok(())
+    }
+}

--- a/bin/src/ws.rs
+++ b/bin/src/ws.rs
@@ -33,7 +33,7 @@ impl<D: RequestHandler> RequestHandler for RequestInterceptor<D> {
     ) -> ResponseInfo {
         let qry = request.query();
         let msg = format!(
-            "[{}, \"{}\",\"{}\",\"{}\",\"{}\"]",
+            "[{}, \"{}\", \"{}\", \"{}\", \"{}\"]",
             SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis(),
             request.src().ip(),
             qry.query_class(),

--- a/bin/src/ws.rs
+++ b/bin/src/ws.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+
+pub(crate) struct RequestInterceptor<D: RequestHandler> {
+    downstream: D
+}
+
+impl<D: RequestHandler> RequestInterceptor<D> {
+    pub(crate) fn new(downstream: D) -> Self {
+        Self { downstream }
+    }
+}
+
+#[async_trait]
+impl<D: RequestHandler> RequestHandler for RequestInterceptor<D> {
+    async fn handle_request<R: ResponseHandler>(&self, request: &Request, response_handle: R) -> ResponseInfo {
+        println!("intercepted request from {}: {} {} {}", request.src(), request.query().query_class(), request.query().query_type(), request.query().name());
+        self.downstream.handle_request(request, response_handle).await
+    }
+}
+

--- a/bin/src/ws.rs
+++ b/bin/src/ws.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info};
@@ -32,7 +33,8 @@ impl<D: RequestHandler> RequestHandler for RequestInterceptor<D> {
     ) -> ResponseInfo {
         let qry = request.query();
         let msg = format!(
-            "[\"{}\",\"{}\",\"{}\",\"{}\"]",
+            "[{}, \"{}\",\"{}\",\"{}\",\"{}\"]",
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis(),
             request.src().ip(),
             qry.query_class(),
             qry.query_type(),


### PR DESCRIPTION
The purpose of this PR is to add monitoring capability of DNS requests that are being resolved by DNS server.

A single-purpose DNS requests interceptor is added. This modifies the behavior of the DNS server, so that besides normal DNS resolution, it also forwards each request to a WebSocket.

Once connected, the WS is only forwarded the DNS requests that originate from the same IP as the WS client.